### PR TITLE
Added expiry support in custom status APIs

### DIFF
--- a/api4/status.go
+++ b/api4/status.go
@@ -127,7 +127,7 @@ func updateUserCustomStatus(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	customStatus := model.CustomStatusFromJson(r.Body)
-	if customStatus == nil || (customStatus.Text == "" && customStatus.Emoji == "") {
+	if customStatus == nil || customStatus.Emoji == "" || !customStatus.IsDurationValid() || !customStatus.IsExpirationTimeValid() {
 		c.SetInvalidParam("custom_status")
 		return
 	}

--- a/model/custom_status.go
+++ b/model/custom_status.go
@@ -55,11 +55,7 @@ func (cs *CustomStatus) IsDurationValid() bool {
 }
 
 func (cs *CustomStatus) IsExpirationTimeValid() bool {
-	if cs.Duration != DontClear && cs.ExpiresAt.IsZero() {
-		return false
-	}
-
-	if cs.ExpiresAt.Before(time.Now()) {
+	if cs.Duration != DontClear && (cs.ExpiresAt.IsZero() || cs.ExpiresAt.Before(time.Now())) {
 		return false
 	}
 

--- a/model/custom_status.go
+++ b/model/custom_status.go
@@ -9,26 +9,27 @@ import (
 	"time"
 )
 
-type Duration string
-
 const (
 	UserPropsKeyCustomStatus = "customStatus"
 
-	CustomStatusTextMaxRunes          = 100
-	MaxRecentCustomStatuses           = 5
-	DontClear                Duration = "dont_clear"
-	ThirtyMinutes                     = "thirty_minutes"
-	OneHour                           = "one_hour"
-	FourHours                         = "four_hours"
-	Today                             = "today"
-	ThisWeek                          = "this_week"
-	CustomDateTime                    = "date_and_time"
+	CustomStatusTextMaxRunes = 100
+	MaxRecentCustomStatuses  = 5
 )
+
+var ValidCustomStatusDuration = map[string]bool{
+	"dont_clear":     true,
+	"thirty_minutes": true,
+	"one_hour":       true,
+	"four_hours":     true,
+	"today":          true,
+	"this_week":      true,
+	"date_and_time":  true,
+}
 
 type CustomStatus struct {
 	Emoji     string    `json:"emoji"`
 	Text      string    `json:"text"`
-	Duration  Duration  `json:"duration"`
+	Duration  string    `json:"duration"`
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
@@ -46,20 +47,11 @@ func (cs *CustomStatus) ToJson() string {
 }
 
 func (cs *CustomStatus) IsDurationValid() bool {
-	switch cs.Duration {
-	case DontClear, ThirtyMinutes, OneHour, FourHours, Today, ThisWeek, CustomDateTime:
-		return true
-	}
-
-	return false
+	return ValidCustomStatusDuration[cs.Duration]
 }
 
 func (cs *CustomStatus) IsExpirationTimeValid() bool {
-	if cs.Duration != DontClear && (cs.ExpiresAt.IsZero() || cs.ExpiresAt.Before(time.Now())) {
-		return false
-	}
-
-	return true
+	return !(cs.Duration != "dont_clear" && (cs.ExpiresAt.IsZero() || cs.ExpiresAt.Before(time.Now())))
 }
 
 func CustomStatusFromJson(data io.Reader) *CustomStatus {


### PR DESCRIPTION
Added validation for the duration and expiration time in request body
Made enum for the custom status durations

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
