### PR TITLE
Added logic to detect and convert unicode emoji to emojiName in custo…

### DIFF
--- a/model/custom_status.go
+++ b/model/custom_status.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strconv"
 )
 
 const (
@@ -37,6 +38,14 @@ func CustomStatusFromJson(data io.Reader) *CustomStatus {
 	var cs *CustomStatus
 	_ = json.NewDecoder(data).Decode(&cs)
 	return cs
+}
+
+func RuneToStringAndUnicode(r rune) (code string, isUnicode bool) {
+	if r < 128 {
+		return string(r), false
+	} else {
+		return strconv.FormatInt(int64(r), 16), true
+	}
 }
 
 type RecentCustomStatuses []CustomStatus

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -15,6 +15,7 @@ const (
 	EMOJI_SORT_BY_NAME    = "name"
 )
 
+var SystemEmojisByFilename map[string]string = createReverseMapOfSystemEmoji()
 var EMOJI_PATTERN = regexp.MustCompile(`:[a-zA-Z0-9_-]+:`)
 
 // ALL_EMOJI_PATTERN is same as the EMOJI_PATTERN except for allowing a '+' character.
@@ -40,6 +41,15 @@ func inSystemEmoji(emojiName string) bool {
 func GetSystemEmojiId(emojiName string) (string, bool) {
 	id, found := SystemEmojis[emojiName]
 	return id, found
+}
+
+func createReverseMapOfSystemEmoji() map[string]string {
+	newMap := make(map[string]string)
+	for key, value := range SystemEmojis {
+		newMap[value] = key
+	}
+
+	return newMap
 }
 
 func (emoji *Emoji) IsValid() *AppError {


### PR DESCRIPTION
…m status slash command

Created reverse map of the SystemEmojis map
Created function to convert rune to ASCII

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
